### PR TITLE
adding new command to notify when dismissing notifications. hide commands from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "kssbkeys",
 	"displayName": "KSSB Keys",
 	"description": "Improving the VSCode experience for users with screen readers.",
-	"version": "1.0.0",
+	"version": "<insert here>",
 	"publisher": "esimkowitz",
 	"license": "MIT",
 	"author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "kssbkeys",
 	"displayName": "KSSB Keys",
 	"description": "Improving the VSCode experience for users with screen readers.",
-	"version": "<insert here>",
+	"version": "1.0.0",
 	"publisher": "esimkowitz",
 	"license": "MIT",
 	"author": {
@@ -34,7 +34,8 @@
 	"activationEvents": [
 		"onStartupFinished",
 		"onView:explorer",
-		"onCommand:kssbkeys.explorerNewFolder"
+		"onCommand:kssbkeys.explorerNewFolder",
+		"onCommand:kssbkeys.dismissNotification"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -42,6 +43,10 @@
 			{
 				"command": "kssbkeys.explorerNewFolder",
 				"title": "KSSB Keys: New Folder"
+			},
+			{
+				"command": "kssbkeys.dismissNotification",
+				"title": "KSSB Keys: Dismiss Notification"
 			}
 		],
 		"keybindings": [
@@ -65,8 +70,27 @@
 				"linux": "tab",
 				"command": "notifications.focusToasts",
 				"when": "notificationToastsVisible && !notificationFocus"
+			},
+			{
+				"mac": "escape",
+				"win": "escape",
+				"linux": "escape",
+				"command": "kssbkeys.dismissNotification",
+				"when": "notificationToastsVisible"
 			}
-		]
+		],
+		"menus": {
+			"commandPalette": [
+				{
+					"command": "kssbkeys.explorerNewFolder",
+					"when": "false"
+				},
+				{
+					"command": "kssbkeys.dismissNotification",
+					"when": "false"
+				}
+			]
+		}
 	},
 	"scripts": {
 		"vscode:prepublish": "yarn run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,11 +2,16 @@ import * as vscode from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
 	const newFolder = vscode.commands.registerCommand('kssbkeys.explorerNewFolder', () => {
-        vscode.window.showInformationMessage("Enter folder name.");
+        vscode.window.showInformationMessage("Enter folder name");
 		vscode.commands.executeCommand("explorer.newFolder");
 	});
 
-	context.subscriptions.push(newFolder);
+	const dismissNotification = vscode.commands.registerCommand('kssbkeys.dismissNotification', () => {
+        vscode.window.showInformationMessage("Notification dismissed");
+		vscode.commands.executeCommand("notifications.hideToasts");
+	});
+
+	context.subscriptions.push(newFolder, dismissNotification);
 }
 
 export function deactivate() {}


### PR DESCRIPTION
I've augmented the default "hide notifications" keybinding to announce that notifications have been dismissed. I've also added a section to the package.json so that the two commands that I've added with this extension don't show up in command palette. If invoked outside of their expected context, these will crash VS Code so hiding them means they can only be invoked by their keyboard shortcut, which is scoped to the correct context.